### PR TITLE
Restore infra files (sansec / merge-upstream / CODEOWNERS) on develop

### DIFF
--- a/.github/workflows/merge-upstream-changes.yml
+++ b/.github/workflows/merge-upstream-changes.yml
@@ -1,0 +1,16 @@
+on:
+  schedule:
+    - cron: "10 10 * * *" # This gives mirror sync, which runs at 9:57, some time to complete.
+  workflow_dispatch: {}
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  merge-from-mirror:
+    uses: mage-os/infrastructure/.github/workflows/merge-upstream-changes.yml@main
+    with:
+      upstream: https://github.com/mage-os/mirror-magento-coding-standard.git
+      matrix: '{ branch: ["develop"] }'
+    secrets:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+      MAGEOS_GITHUB_TOKEN: ${{ secrets.MAGE_OS_CI_TOKEN }}

--- a/.github/workflows/sansec-ecomscan.yml
+++ b/.github/workflows/sansec-ecomscan.yml
@@ -1,0 +1,41 @@
+name: Sansec eComscan Security Scan
+
+on:
+  push:
+  pull_request_target:
+  workflow_dispatch:
+
+jobs:
+  run-ecomscan:
+    # Skip if it's a push event on a PR (it can't access secrets)
+    if: github.event.pull_request == null || github.event_name != 'push'
+    name: Run Sansec eComscan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Download eComscan
+        run: wget https://ecomscan.com/downloads/linux-amd64/ecomscan
+
+      - name: Fix permissions
+        run: chmod +x ecomscan
+
+      - name: Run eComscan
+        env:
+          ECOMSCAN_KEY: ${{ secrets.SANSEC_LICENSE_KEY }}
+          ECOMSCAN_SKIP_SERVER_CHECKS: 1
+        run: |
+          output=$(./ecomscan --no-auto-update --skip-database --deep --format=csv .)
+          if [ -n "$output" ]; then
+            echo "Security issues found:"
+            echo "$output"
+            exit 1
+          fi

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Mage-OS/distribution


### PR DESCRIPTION
Restores infrastructure files from `main` that the release PR would otherwise remove when merged.

Files restored:
- \\`.github/workflows/merge-upstream-changes.yml\\`
- \\`.github/workflows/sansec-ecomscan.yml\\`
- \\`CODEOWNERS\\`

Merge this before the corresponding release-prep PR so the infra files are preserved on `develop` and on `main`.